### PR TITLE
Fix double workflow run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
## Why are the changes necessary?

When a PR is created, two workflow events are triggered instead of one.

## What does this pull request cover?

- Run test workflow once for a PR

## Breaking changes

None.

