### PR TITLE
fix: gracefully handle pasting an empty clipboard

### DIFF
--- a/app/clipboard.py
+++ b/app/clipboard.py
@@ -33,6 +33,8 @@ class RedisClipboard(Clipboard):
 
     def paste(self, stream):
         try:
-            stream.write(self.conn.get(self.STORE_KEY))
+            data = self.conn.get(self.STORE_KEY)
+            if data is not None:
+                stream.write(data)
         except redis.exceptions.TimeoutError:
             click.ClickException("Connection timed out.").show()

--- a/tests/app/test_clipboard.py
+++ b/tests/app/test_clipboard.py
@@ -26,6 +26,12 @@ class TestRediClipboard(unittest.TestCase):
         stream.seek(0)
         self.assertEqual(b"test.paste", stream.read())
 
+    def test_paste_empty(self):
+        stream = io.BytesIO()
+        self.subject.paste(stream)
+        stream.seek(0)
+        self.assertEqual(b"", stream.read())
+
     def test_copy_paste(self):
         in_stream = io.BytesIO(b"some.url.dot.com")
         out_stream = io.BytesIO()


### PR DESCRIPTION
## Summary
- `klippy paste` with nothing copied raised a `TypeError` because `conn.get()` returns `None` and that was passed straight to `stream.write()`.
- `RedisClipboard.paste` now skips the write when the store key is unset, so the output is simply empty.
- Added a `test_paste_empty` case covering the empty-clipboard path.

Fixes #117

## Test plan
- [x] `python -m pytest tests/` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)