### PR TITLE
feat: respect XDG base directory for the config file

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,11 +1,9 @@
 import configparser
 import os
-import shutil
 from pathlib import Path
 
 
 class Settings:
-    LEGACY_PATH = f"{Path.home()}/.klippy.ini"
     PATH = f"{os.environ.get('XDG_CONFIG_HOME') or f'{Path.home()}/.config'}/klippy/config.ini"
 
     MAIN_DEFAULTS = {
@@ -57,12 +55,4 @@ class Settings:
         for key, value in self.DEFAULTS.items():
             self.config.setdefault(key, value)
 
-        self.__migrate_legacy_config()
         self.config.read(self.PATH)
-
-    def __migrate_legacy_config(self):
-        if os.path.exists(self.PATH) or not os.path.exists(self.LEGACY_PATH):
-            return
-
-        Path(self.PATH).parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(self.LEGACY_PATH, self.PATH)

--- a/app/config.py
+++ b/app/config.py
@@ -1,9 +1,12 @@
 import configparser
+import os
+import shutil
 from pathlib import Path
 
 
 class Settings:
-    PATH = f"{Path.home()}/.klippy.ini"
+    LEGACY_PATH = f"{Path.home()}/.klippy.ini"
+    PATH = f"{os.environ.get('XDG_CONFIG_HOME') or f'{Path.home()}/.config'}/klippy/config.ini"
 
     MAIN_DEFAULTS = {
         "namespace": "default",
@@ -46,6 +49,7 @@ class Settings:
         self.__save()
 
     def __save(self):
+        Path(self.PATH).parent.mkdir(parents=True, exist_ok=True)
         with open(self.PATH, "w+") as configfile:
             self.config.write(configfile)
 
@@ -53,4 +57,12 @@ class Settings:
         for key, value in self.DEFAULTS.items():
             self.config.setdefault(key, value)
 
+        self.__migrate_legacy_config()
         self.config.read(self.PATH)
+
+    def __migrate_legacy_config(self):
+        if os.path.exists(self.PATH) or not os.path.exists(self.LEGACY_PATH):
+            return
+
+        Path(self.PATH).parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(self.LEGACY_PATH, self.PATH)

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -1,19 +1,23 @@
 import os
+import shutil
 import unittest
 
 from app.config import Settings
 
 
 class TestConfig(unittest.TestCase):
-    TEMP_CONFIG_PATH = "tests/.tmp.ini"
+    TEMP_CONFIG_PATH = "tests/.tmp/config.ini"
+    TEMP_LEGACY_CONFIG_PATH = "tests/.tmp.legacy.ini"
 
     def setUp(self):
         Settings.PATH = self.TEMP_CONFIG_PATH
+        Settings.LEGACY_PATH = self.TEMP_LEGACY_CONFIG_PATH
         self.subject = Settings()
 
     def tearDown(self):
-        if os.path.exists(Settings.PATH):
-            os.remove(Settings.PATH)
+        if os.path.exists(Settings.LEGACY_PATH):
+            os.remove(Settings.LEGACY_PATH)
+        shutil.rmtree("tests/.tmp", ignore_errors=True)
 
     def test_defaults(self):
         expected_namespace = "default"
@@ -29,3 +33,25 @@ class TestConfig(unittest.TestCase):
         self.subject.set_redis("test.klippy", "12345", "secret")
         expected = {"host": "test.klippy", "port": "12345", "password": "secret"}
         self.assertEqual(expected, self.subject.redis())
+
+    def test_save_creates_parent_directories(self):
+        self.subject.set_namespace("test")
+        self.assertTrue(os.path.exists(self.TEMP_CONFIG_PATH))
+
+    def test_migrates_legacy_config(self):
+        with open(self.TEMP_LEGACY_CONFIG_PATH, "w") as legacy_file:
+            legacy_file.write("[main]\nnamespace = legacy_namespace\n")
+
+        subject = Settings()
+        self.assertEqual("legacy_namespace", subject.namespace())
+        self.assertTrue(os.path.exists(self.TEMP_CONFIG_PATH))
+        self.assertFalse(os.path.exists(self.TEMP_LEGACY_CONFIG_PATH))
+
+    def test_does_not_migrate_when_config_exists(self):
+        self.subject.set_namespace("current_namespace")
+        with open(self.TEMP_LEGACY_CONFIG_PATH, "w") as legacy_file:
+            legacy_file.write("[main]\nnamespace = legacy_namespace\n")
+
+        subject = Settings()
+        self.assertEqual("current_namespace", subject.namespace())
+        self.assertTrue(os.path.exists(self.TEMP_LEGACY_CONFIG_PATH))

--- a/tests/app/test_config.py
+++ b/tests/app/test_config.py
@@ -7,16 +7,12 @@ from app.config import Settings
 
 class TestConfig(unittest.TestCase):
     TEMP_CONFIG_PATH = "tests/.tmp/config.ini"
-    TEMP_LEGACY_CONFIG_PATH = "tests/.tmp.legacy.ini"
 
     def setUp(self):
         Settings.PATH = self.TEMP_CONFIG_PATH
-        Settings.LEGACY_PATH = self.TEMP_LEGACY_CONFIG_PATH
         self.subject = Settings()
 
     def tearDown(self):
-        if os.path.exists(Settings.LEGACY_PATH):
-            os.remove(Settings.LEGACY_PATH)
         shutil.rmtree("tests/.tmp", ignore_errors=True)
 
     def test_defaults(self):
@@ -37,21 +33,3 @@ class TestConfig(unittest.TestCase):
     def test_save_creates_parent_directories(self):
         self.subject.set_namespace("test")
         self.assertTrue(os.path.exists(self.TEMP_CONFIG_PATH))
-
-    def test_migrates_legacy_config(self):
-        with open(self.TEMP_LEGACY_CONFIG_PATH, "w") as legacy_file:
-            legacy_file.write("[main]\nnamespace = legacy_namespace\n")
-
-        subject = Settings()
-        self.assertEqual("legacy_namespace", subject.namespace())
-        self.assertTrue(os.path.exists(self.TEMP_CONFIG_PATH))
-        self.assertFalse(os.path.exists(self.TEMP_LEGACY_CONFIG_PATH))
-
-    def test_does_not_migrate_when_config_exists(self):
-        self.subject.set_namespace("current_namespace")
-        with open(self.TEMP_LEGACY_CONFIG_PATH, "w") as legacy_file:
-            legacy_file.write("[main]\nnamespace = legacy_namespace\n")
-
-        subject = Settings()
-        self.assertEqual("current_namespace", subject.namespace())
-        self.assertTrue(os.path.exists(self.TEMP_LEGACY_CONFIG_PATH))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,11 +11,9 @@ from app.config import Settings
 
 class TestCliConfigure(unittest.TestCase):
     TEMP_CONFIG_PATH = "tests/.tmp.ini"
-    TEMP_LEGACY_CONFIG_PATH = "tests/.tmp.legacy.ini"
 
     def setUp(self):
         Settings.PATH = self.TEMP_CONFIG_PATH
-        Settings.LEGACY_PATH = self.TEMP_LEGACY_CONFIG_PATH
         self.__run_with_sample_prompt_value()
 
     def tearDown(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,9 +11,11 @@ from app.config import Settings
 
 class TestCliConfigure(unittest.TestCase):
     TEMP_CONFIG_PATH = "tests/.tmp.ini"
+    TEMP_LEGACY_CONFIG_PATH = "tests/.tmp.legacy.ini"
 
     def setUp(self):
         Settings.PATH = self.TEMP_CONFIG_PATH
+        Settings.LEGACY_PATH = self.TEMP_LEGACY_CONFIG_PATH
         self.__run_with_sample_prompt_value()
 
     def tearDown(self):


### PR DESCRIPTION
## Summary

Closes #116.

- Move the settings file from `$HOME/.klippy.ini` to `$XDG_CONFIG_HOME/klippy/config.ini`, falling back to `$HOME/.config/klippy/config.ini` when `XDG_CONFIG_HOME` is unset or empty (per the XDG Base Directory spec).
- Saving now creates the `klippy/` config directory if it doesn't exist.
- The `klippy configure` help text picks up the new path automatically since it interpolates `Settings.PATH`.

Note: there is no migration of an existing `~/.klippy.ini` — users with an existing config need to move it to the new location or re-run `klippy configure`.

## Tests

- New test for parent-directory creation on save.
- `pipenv run pytest`: 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)