### PR TITLE
feat: add doctor command to check configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ pip install klippy
 # or have multiple clipboards, use different namespaces.
 klippy configure
 
+# Check the configuration and the connection to the Redis server
+klippy doctor
+
 # Copy data to the cloud clipboard (Redis database)
 klippy copy file.png
 klippy copy < file.txt

--- a/app/clipboard.py
+++ b/app/clipboard.py
@@ -20,10 +20,16 @@ class Clipboard:
     def paste(self, stream):
         pass
 
+    def ping(self):
+        pass
+
 
 class RedisClipboard(Clipboard):
     def __init__(self):
         self.conn = redis.Redis(**Settings.instance().redis(), socket_connect_timeout=3)
+
+    def ping(self):
+        self.conn.ping()
 
     def copy(self, stream):
         try:

--- a/cli.py
+++ b/cli.py
@@ -1,4 +1,7 @@
+import os
+
 import click
+import redis
 
 from app.clipboard import RedisClipboard
 from app.config import Settings
@@ -36,6 +39,23 @@ def configure():
     password = click.prompt("Enter Redis password", default="")
     Settings.instance().set_namespace(namespace)
     Settings.instance().set_redis(host, port, password)
+
+
+@cli.command(help="Check the configuration and the connection to the Redis server.")
+def doctor():
+    config_status = "found" if os.path.exists(Settings.PATH) else "not found, using defaults"
+    click.echo(f"Settings file: {Settings.PATH} ({config_status})")
+    click.echo(f"Namespace: {Settings.instance().namespace()}")
+
+    redis_settings = Settings.instance().redis()
+    click.echo(f"Redis server: {redis_settings['host']}:{redis_settings['port']}")
+
+    try:
+        RedisClipboard.instance().ping()
+    except redis.exceptions.RedisError as error:
+        raise click.ClickException(f"Connection failed. ({error})")
+
+    click.secho("Connection: OK", fg="green")
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,6 +50,27 @@ class TestCliConfigure(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
 
+class TestCliDoctor(unittest.TestCase):
+    def setUp(self):
+        RedisClipboard.instance().conn = fakeredis.FakeStrictRedis()
+
+    def test_success(self):
+        result = CliRunner().invoke(cli.doctor)
+        self.assertFalse(result.exception)
+        self.assertEqual(0, result.exit_code)
+        self.assertIn(f"Settings file: {Settings.PATH}", result.output)
+        self.assertIn(f"Namespace: {Settings.instance().namespace()}", result.output)
+        self.assertIn("Connection: OK", result.output)
+
+    def test_connection_failure(self):
+        server = fakeredis.FakeServer()
+        server.connected = False
+        RedisClipboard.instance().conn = fakeredis.FakeStrictRedis(server=server)
+        result = CliRunner().invoke(cli.doctor)
+        self.assertEqual(1, result.exit_code)
+        self.assertIn("Connection failed.", result.output)
+
+
 class TestCliCopyPaste(unittest.TestCase):
     def setUp(self):
         RedisClipboard.instance().conn = fakeredis.FakeStrictRedis()


### PR DESCRIPTION
## Summary

Closes #118.

Adds a `klippy doctor` command so the configuration can be tested without doing an actual copy/paste:

```
$ klippy doctor
Settings file: /home/raza/.klippy.ini (not found, using defaults)
Namespace: default
Redis server: 127.0.0.1:6379
Error: Connection failed. (Error 111 connecting to 127.0.0.1:6379. Connection refused.)
```

- Reports the settings file path and whether it was found, the configured namespace, and the Redis host/port.
- Verifies the connection by pinging the Redis server (via a new `ping()` on the clipboard), printing `Connection: OK` on success and exiting with status 1 on any Redis error.
- Documents the new command in the README usage section.

## Tests

- New `TestCliDoctor` covering the success path (settings summary + `Connection: OK`, exit 0) and the connection-failure path (error message, exit 1) using a disconnected `fakeredis.FakeServer`.
- `pipenv run pytest`: 13 passed. Also verified manually (output above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)