### PR TITLE
fix: resolve the clipboard store key lazily

### DIFF
--- a/src/klippy/clipboard.py
+++ b/src/klippy/clipboard.py
@@ -5,14 +5,15 @@ from klippy.config import Settings
 
 
 class Clipboard:
-    STORE_KEY = f"klippy.{Settings.instance().namespace()}"
-
     __instance = None
 
     @classmethod
     def instance(cls):
         cls.__instance = cls.__instance or cls()
         return cls.__instance
+
+    def store_key(self):
+        return f"klippy.{Settings.instance().namespace()}"
 
     def copy(self, stream):
         pass
@@ -33,13 +34,13 @@ class RedisClipboard(Clipboard):
 
     def copy(self, stream):
         try:
-            self.conn.set(self.STORE_KEY, stream.read())
+            self.conn.set(self.store_key(), stream.read())
         except redis.exceptions.TimeoutError:
             click.ClickException("Connection timed out.").show()
 
     def paste(self, stream):
         try:
-            data = self.conn.get(self.STORE_KEY)
+            data = self.conn.get(self.store_key())
             if data is not None:
                 stream.write(data)
         except redis.exceptions.TimeoutError:

--- a/tests/klippy/test_clipboard.py
+++ b/tests/klippy/test_clipboard.py
@@ -17,10 +17,10 @@ class TestRediClipboard(unittest.TestCase):
     def test_copy(self):
         stream = io.BytesIO(b"test.copy")
         self.subject.copy(stream)
-        self.assertEqual(b"test.copy", self.subject.conn.get(self.subject.STORE_KEY))
+        self.assertEqual(b"test.copy", self.subject.conn.get(self.subject.store_key()))
 
     def test_paste(self):
-        self.subject.conn.set(self.subject.STORE_KEY, b"test.paste")
+        self.subject.conn.set(self.subject.store_key(), b"test.paste")
         stream = io.BytesIO()
         self.subject.paste(stream)
         stream.seek(0)


### PR DESCRIPTION
## Stack 3/8 — merge after #319

`STORE_KEY` was a class attribute evaluated at import time, which froze the namespace before any command ran and instantiated the `Settings` singleton as an import side effect.

## Changes

- The store key is now computed per operation via a `store_key()` method, so namespace changes take effect without re-importing — and it unblocks removing the singletons in the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)