### PR TITLE
refactor: replace singletons with injected settings

### DIFF
--- a/src/klippy/cli.py
+++ b/src/klippy/cli.py
@@ -22,36 +22,39 @@ def cli():
 @cli.command(help="Copy the data from file or stdin.")
 @click.argument("file", required=False, type=click.File("rb"))
 def copy(file):
-    RedisClipboard.instance().copy(file or click.get_binary_stream("stdin"))
+    RedisClipboard(Settings()).copy(file or click.get_binary_stream("stdin"))
 
 
 @cli.command(help="Paste the data to file or stdout.")
 @click.argument("file", required=False, type=click.File("wb"))
 def paste(file):
-    RedisClipboard.instance().paste(file or click.get_binary_stream("stdout"))
+    RedisClipboard(Settings()).paste(file or click.get_binary_stream("stdout"))
 
 
 @cli.command(help=f"Configure settings file. ({Settings.PATH})")
 def configure():
-    namespace = click.prompt("Enter the name of namespace", default=Settings.instance().namespace())
-    host = click.prompt("Enter Redis host", default=Settings.instance().redis().get("host"))
-    port = click.prompt("Enter Redis port", default=Settings.instance().redis().get("port"))
+    settings = Settings()
+    namespace = click.prompt("Enter the name of namespace", default=settings.namespace())
+    host = click.prompt("Enter Redis host", default=settings.redis().get("host"))
+    port = click.prompt("Enter Redis port", default=settings.redis().get("port"))
     password = click.prompt("Enter Redis password", default="")
-    Settings.instance().set_namespace(namespace)
-    Settings.instance().set_redis(host, port, password)
+    settings.set_namespace(namespace)
+    settings.set_redis(host, port, password)
 
 
 @cli.command(help="Check the configuration and the connection to the Redis server.")
 def doctor():
+    settings = Settings()
+
     config_status = "found" if os.path.exists(Settings.PATH) else "not found, using defaults"
     click.echo(f"Settings file: {Settings.PATH} ({config_status})")
-    click.echo(f"Namespace: {Settings.instance().namespace()}")
+    click.echo(f"Namespace: {settings.namespace()}")
 
-    redis_settings = Settings.instance().redis()
+    redis_settings = settings.redis()
     click.echo(f"Redis server: {redis_settings['host']}:{redis_settings['port']}")
 
     try:
-        RedisClipboard.instance().ping()
+        RedisClipboard(settings).ping()
     except redis.exceptions.RedisError as error:
         raise click.ClickException(f"Connection failed. ({error})")
 

--- a/src/klippy/clipboard.py
+++ b/src/klippy/clipboard.py
@@ -1,33 +1,14 @@
 import click
 import redis
 
-from klippy.config import Settings
 
-
-class Clipboard:
-    __instance = None
-
-    @classmethod
-    def instance(cls):
-        cls.__instance = cls.__instance or cls()
-        return cls.__instance
+class RedisClipboard:
+    def __init__(self, settings):
+        self.settings = settings
+        self.conn = redis.Redis(**settings.redis(), socket_connect_timeout=3)
 
     def store_key(self):
-        return f"klippy.{Settings.instance().namespace()}"
-
-    def copy(self, stream):
-        pass
-
-    def paste(self, stream):
-        pass
-
-    def ping(self):
-        pass
-
-
-class RedisClipboard(Clipboard):
-    def __init__(self):
-        self.conn = redis.Redis(**Settings.instance().redis(), socket_connect_timeout=3)
+        return f"klippy.{self.settings.namespace()}"
 
     def ping(self):
         self.conn.ping()

--- a/src/klippy/config.py
+++ b/src/klippy/config.py
@@ -21,16 +21,9 @@ class Settings:
         "redis": REDIS_DEFAULTS,
     }
 
-    __instance = None
-
     def __init__(self):
         self.config = configparser.ConfigParser()
         self.__load()
-
-    @classmethod
-    def instance(cls):
-        cls.__instance = cls.__instance or cls()
-        return cls.__instance
 
     def redis(self):
         return dict(self.config["redis"])

--- a/tests/klippy/test_clipboard.py
+++ b/tests/klippy/test_clipboard.py
@@ -4,15 +4,19 @@ import unittest
 import fakeredis
 
 from klippy.clipboard import RedisClipboard
+from klippy.config import Settings
 
 
-class TestRediClipboard(unittest.TestCase):
+class TestRedisClipboard(unittest.TestCase):
     def setUp(self):
-        self.subject = RedisClipboard().instance()
+        self.original_settings_path = Settings.PATH
+        Settings.PATH = "tests/.tmp.ini"
+        self.subject = RedisClipboard(Settings())
         self.subject.conn = fakeredis.FakeStrictRedis()
 
     def tearDown(self):
         self.subject.conn.close()
+        Settings.PATH = self.original_settings_path
 
     def test_copy(self):
         stream = io.BytesIO(b"test.copy")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,24 +1,39 @@
 import os
 import unittest
+from unittest import mock
 
 import fakeredis
 from click.testing import CliRunner
 
 from klippy import cli
-from klippy.clipboard import RedisClipboard
 from klippy.config import Settings
 
 
-class TestCliConfigure(unittest.TestCase):
+class CliTestCase(unittest.TestCase):
     TEMP_CONFIG_PATH = "tests/.tmp.ini"
 
     def setUp(self):
+        self.original_settings_path = Settings.PATH
         Settings.PATH = self.TEMP_CONFIG_PATH
-        self.__run_with_sample_prompt_value()
+
+        self.server = fakeredis.FakeServer()
+        patcher = mock.patch(
+            "klippy.clipboard.redis.Redis",
+            lambda **kwargs: fakeredis.FakeStrictRedis(server=self.server),
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def tearDown(self):
         if os.path.exists(Settings.PATH):
             os.remove(Settings.PATH)
+        Settings.PATH = self.original_settings_path
+
+
+class TestCliConfigure(CliTestCase):
+    def setUp(self):
+        super().setUp()
+        self.__run_with_sample_prompt_value()
 
     def test_settings(self):
         expected_namespace = "my_namespace"
@@ -27,8 +42,8 @@ class TestCliConfigure(unittest.TestCase):
             "port": "12345",
             "password": "secret-password",
         }
-        self.assertEqual(expected_namespace, Settings.instance().namespace())
-        self.assertEqual(expected_redis, Settings.instance().redis())
+        self.assertEqual(expected_namespace, Settings().namespace())
+        self.assertEqual(expected_redis, Settings().redis())
 
     def test_config_file(self):
         with open(self.TEMP_CONFIG_PATH, "r") as f:
@@ -50,31 +65,23 @@ class TestCliConfigure(unittest.TestCase):
         self.assertEqual(0, result.exit_code)
 
 
-class TestCliDoctor(unittest.TestCase):
-    def setUp(self):
-        RedisClipboard.instance().conn = fakeredis.FakeStrictRedis()
-
+class TestCliDoctor(CliTestCase):
     def test_success(self):
         result = CliRunner().invoke(cli.doctor)
         self.assertFalse(result.exception)
         self.assertEqual(0, result.exit_code)
         self.assertIn(f"Settings file: {Settings.PATH}", result.output)
-        self.assertIn(f"Namespace: {Settings.instance().namespace()}", result.output)
+        self.assertIn("Namespace: default", result.output)
         self.assertIn("Connection: OK", result.output)
 
     def test_connection_failure(self):
-        server = fakeredis.FakeServer()
-        server.connected = False
-        RedisClipboard.instance().conn = fakeredis.FakeStrictRedis(server=server)
+        self.server.connected = False
         result = CliRunner().invoke(cli.doctor)
         self.assertEqual(1, result.exit_code)
         self.assertIn("Connection failed.", result.output)
 
 
-class TestCliCopyPaste(unittest.TestCase):
-    def setUp(self):
-        RedisClipboard.instance().conn = fakeredis.FakeStrictRedis()
-
+class TestCliCopyPaste(CliTestCase):
     def test_flow(self):
         runner = CliRunner()
         sample_data = os.urandom(1024)
@@ -82,15 +89,13 @@ class TestCliCopyPaste(unittest.TestCase):
             with open("input.dat", "wb") as input_file:
                 input_file.write(sample_data)
 
-            with open("input.dat", "rb") as input_file:
-                result = runner.invoke(cli.copy, "input.dat")
-                self.assertFalse(result.exception)
-                self.assertEqual(0, result.exit_code)
+            result = runner.invoke(cli.copy, "input.dat")
+            self.assertFalse(result.exception)
+            self.assertEqual(0, result.exit_code)
 
-            with open("output.dat", "wb") as output_file:
-                result = runner.invoke(cli.paste, "output.dat")
-                self.assertFalse(result.exception)
-                self.assertEqual(0, result.exit_code)
+            result = runner.invoke(cli.paste, "output.dat")
+            self.assertFalse(result.exception)
+            self.assertEqual(0, result.exit_code)
 
             with open("output.dat", "rb") as output_file:
                 self.assertEqual(sample_data, output_file.read())


### PR DESCRIPTION
## Stack 4/8 — merge after #320

`Settings.instance()` and `RedisClipboard.instance()` made state global and tests order-dependent.

## Changes

- `RedisClipboard` now takes a `Settings` object; each CLI command builds its own instances. The unused no-op `Clipboard` base class is gone.
- CLI tests patch `redis.Redis` with a fakeredis factory bound to a per-test `FakeServer` instead of mutating the shared singleton connection — clipboard state no longer leaks between tests.
- Fixed a latent test leak: `Settings.PATH` is now restored after each test (it was mutated globally and never reset, previously masked by the singleton cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)