### PR TITLE
fix: exit non-zero when copy or paste cannot reach Redis

### DIFF
--- a/src/klippy/cli.py
+++ b/src/klippy/cli.py
@@ -22,13 +22,19 @@ def cli():
 @cli.command(help="Copy the data from file or stdin.")
 @click.argument("file", required=False, type=click.File("rb"))
 def copy(file):
-    RedisClipboard(Settings()).copy(file or click.get_binary_stream("stdin"))
+    try:
+        RedisClipboard(Settings()).copy(file or click.get_binary_stream("stdin"))
+    except redis.exceptions.RedisError as error:
+        raise click.ClickException(f"Copy failed, try 'klippy doctor'. ({error})")
 
 
 @cli.command(help="Paste the data to file or stdout.")
 @click.argument("file", required=False, type=click.File("wb"))
 def paste(file):
-    RedisClipboard(Settings()).paste(file or click.get_binary_stream("stdout"))
+    try:
+        RedisClipboard(Settings()).paste(file or click.get_binary_stream("stdout"))
+    except redis.exceptions.RedisError as error:
+        raise click.ClickException(f"Paste failed, try 'klippy doctor'. ({error})")
 
 
 @cli.command(help=f"Configure settings file. ({Settings.PATH})")

--- a/src/klippy/clipboard.py
+++ b/src/klippy/clipboard.py
@@ -1,4 +1,3 @@
-import click
 import redis
 
 
@@ -14,15 +13,9 @@ class RedisClipboard:
         self.conn.ping()
 
     def copy(self, stream):
-        try:
-            self.conn.set(self.store_key(), stream.read())
-        except redis.exceptions.TimeoutError:
-            click.ClickException("Connection timed out.").show()
+        self.conn.set(self.store_key(), stream.read())
 
     def paste(self, stream):
-        try:
-            data = self.conn.get(self.store_key())
-            if data is not None:
-                stream.write(data)
-        except redis.exceptions.TimeoutError:
-            click.ClickException("Connection timed out.").show()
+        data = self.conn.get(self.store_key())
+        if data is not None:
+            stream.write(data)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -82,6 +82,18 @@ class TestCliDoctor(CliTestCase):
 
 
 class TestCliCopyPaste(CliTestCase):
+    def test_copy_connection_failure(self):
+        self.server.connected = False
+        result = CliRunner().invoke(cli.copy, input=b"sample")
+        self.assertEqual(1, result.exit_code)
+        self.assertIn("Copy failed", result.output)
+
+    def test_paste_connection_failure(self):
+        self.server.connected = False
+        result = CliRunner().invoke(cli.paste)
+        self.assertEqual(1, result.exit_code)
+        self.assertIn("Paste failed", result.output)
+
     def test_flow(self):
         runner = CliRunner()
         sample_data = os.urandom(1024)


### PR DESCRIPTION
## Stack 5/8 — merge after #321

`copy` and `paste` caught only `TimeoutError` and called `ClickException(...).show()` without raising, so failures printed an error yet exited 0 — a piped `klippy paste > file` silently produced an empty file and a truthy exit. Connection errors weren't caught at all and dumped a raw traceback.

## Changes

- The CLI now catches `redis.exceptions.RedisError` (parent of both timeout and connection errors) and raises `ClickException`, matching the existing `doctor` pattern: clean error message, exit code 1.
- `RedisClipboard` no longer does its own error handling (or imports click).
- New tests assert exit code 1 and the error message for copy/paste against a disconnected server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)