### PR TITLE
fix: hide the password prompt and preserve it on reconfigure

### DIFF
--- a/src/klippy/cli.py
+++ b/src/klippy/cli.py
@@ -43,7 +43,12 @@ def configure():
     namespace = click.prompt("Enter the name of namespace", default=settings.namespace())
     host = click.prompt("Enter Redis host", default=settings.redis().get("host"))
     port = click.prompt("Enter Redis port", default=settings.redis().get("port"))
-    password = click.prompt("Enter Redis password", default="")
+    password = click.prompt(
+        "Enter Redis password",
+        default=settings.redis().get("password", ""),
+        hide_input=True,
+        show_default=False,
+    )
     settings.set_namespace(namespace)
     settings.set_redis(host, port, password)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -57,12 +57,22 @@ class TestCliConfigure(CliTestCase):
             )
             self.assertEqual(expected, f.read())
 
+    def test_password_is_not_echoed(self):
+        self.assertNotIn("secret-password", self.configure_result.output)
+
+    def test_reconfigure_preserves_password(self):
+        result = CliRunner().invoke(cli.configure, input="\n\n\n\n")
+        self.assertFalse(result.exception)
+        self.assertEqual(0, result.exit_code)
+        self.assertEqual("secret-password", Settings().redis()["password"])
+        self.assertNotIn("secret-password", result.output)
+
     def __run_with_sample_prompt_value(self):
         prompt_input = "my_namespace\n" "test.redis.io\n" "12345\n" "secret-password\n"
 
-        result = CliRunner().invoke(cli.configure, input=prompt_input)
-        self.assertFalse(result.exception)
-        self.assertEqual(0, result.exit_code)
+        self.configure_result = CliRunner().invoke(cli.configure, input=prompt_input)
+        self.assertFalse(self.configure_result.exception)
+        self.assertEqual(0, self.configure_result.exit_code)
 
 
 class TestCliDoctor(CliTestCase):


### PR DESCRIPTION
## Stack 6/8 — merge after #322

`klippy configure` echoed the password as it was typed, and always defaulted it to an empty string — so reconfiguring any other setting silently wiped a stored password.

## Changes

- The password prompt now hides input and defaults to the existing password without displaying it (`hide_input=True, show_default=False`), so pressing Enter keeps it.
- New tests: the password never appears in prompt output, and reconfiguring with all-Enter preserves it.

Note: clearing a stored password now requires editing the config file directly — an acceptable trade-off for not wiping it by accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)