### PR TITLE
feat: add clip expiry and a clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ klippy copy file.png
 klippy copy < file.txt
 echo "$PATH" | klippy copy
 
+# Copy data that expires after a duration (e.g. 90s, 5m, 2h, 1d)
+klippy copy --expire 1h file.png
+
 # Paste data from the clipboard (Redis database)
 klippy paste file.png
 klippy paste > file.txt
 klippy paste | cat
+
+# Clear the clipboard
+klippy clear
 ```
 
 ## 🧞‍♂️ Wishlist

--- a/src/klippy/cli.py
+++ b/src/klippy/cli.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 import click
 import redis
@@ -19,11 +20,33 @@ def cli():
     pass
 
 
+def parse_duration(ctx, param, value):
+    if value is None:
+        return None
+
+    match = re.fullmatch(r"(\d+)([smhd])", value)
+    if not match:
+        raise click.BadParameter("expected a number followed by a unit, e.g. 90s, 5m, 2h, 1d")
+
+    seconds_per_unit = {"s": 1, "m": 60, "h": 3600, "d": 86400}
+    seconds = int(match.group(1)) * seconds_per_unit[match.group(2)]
+    if seconds == 0:
+        raise click.BadParameter("duration must be greater than zero")
+
+    return seconds
+
+
 @cli.command(help="Copy the data from file or stdin.")
 @click.argument("file", required=False, type=click.File("rb"))
-def copy(file):
+@click.option(
+    "--expire",
+    "-e",
+    callback=parse_duration,
+    help="Expire the clip after a duration, e.g. 90s, 5m, 2h, 1d.",
+)
+def copy(file, expire):
     try:
-        RedisClipboard(Settings()).copy(file or click.get_binary_stream("stdin"))
+        RedisClipboard(Settings()).copy(file or click.get_binary_stream("stdin"), expire=expire)
     except redis.exceptions.RedisError as error:
         raise click.ClickException(f"Copy failed, try 'klippy doctor'. ({error})")
 
@@ -35,6 +58,15 @@ def paste(file):
         RedisClipboard(Settings()).paste(file or click.get_binary_stream("stdout"))
     except redis.exceptions.RedisError as error:
         raise click.ClickException(f"Paste failed, try 'klippy doctor'. ({error})")
+
+
+@cli.command(help="Clear the clipboard.")
+def clear():
+    try:
+        RedisClipboard(Settings()).clear()
+    except redis.exceptions.RedisError as error:
+        raise click.ClickException(f"Clear failed, try 'klippy doctor'. ({error})")
+    click.echo("Clipboard cleared.")
 
 
 @cli.command(help=f"Configure settings file. ({Settings.PATH})")

--- a/src/klippy/clipboard.py
+++ b/src/klippy/clipboard.py
@@ -12,10 +12,13 @@ class RedisClipboard:
     def ping(self):
         self.conn.ping()
 
-    def copy(self, stream):
-        self.conn.set(self.store_key(), stream.read())
+    def copy(self, stream, expire=None):
+        self.conn.set(self.store_key(), stream.read(), ex=expire)
 
     def paste(self, stream):
         data = self.conn.get(self.store_key())
         if data is not None:
             stream.write(data)
+
+    def clear(self):
+        self.conn.delete(self.store_key())

--- a/tests/klippy/test_clipboard.py
+++ b/tests/klippy/test_clipboard.py
@@ -36,6 +36,16 @@ class TestRedisClipboard(unittest.TestCase):
         stream.seek(0)
         self.assertEqual(b"", stream.read())
 
+    def test_copy_with_expire(self):
+        stream = io.BytesIO(b"test.expire")
+        self.subject.copy(stream, expire=60)
+        self.assertEqual(60, self.subject.conn.ttl(self.subject.store_key()))
+
+    def test_clear(self):
+        self.subject.conn.set(self.subject.store_key(), b"test.clear")
+        self.subject.clear()
+        self.assertIsNone(self.subject.conn.get(self.subject.store_key()))
+
     def test_copy_paste(self):
         in_stream = io.BytesIO(b"some.url.dot.com")
         out_stream = io.BytesIO()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,6 +92,23 @@ class TestCliDoctor(CliTestCase):
 
 
 class TestCliCopyPaste(CliTestCase):
+    def test_copy_with_expire(self):
+        result = CliRunner().invoke(cli.copy, ["--expire", "5m"], input=b"sample")
+        self.assertEqual(0, result.exit_code)
+        conn = fakeredis.FakeStrictRedis(server=self.server)
+        self.assertAlmostEqual(300, conn.ttl("klippy.default"), delta=30)
+
+    def test_copy_with_expire_in_seconds(self):
+        result = CliRunner().invoke(cli.copy, ["-e", "90s"], input=b"sample")
+        self.assertEqual(0, result.exit_code)
+        conn = fakeredis.FakeStrictRedis(server=self.server)
+        self.assertAlmostEqual(90, conn.ttl("klippy.default"), delta=30)
+
+    def test_copy_with_invalid_expire(self):
+        for invalid in ["abc", "90", "5x", "0s"]:
+            result = CliRunner().invoke(cli.copy, ["--expire", invalid], input=b"sample")
+            self.assertEqual(2, result.exit_code)
+
     def test_copy_connection_failure(self):
         self.server.connected = False
         result = CliRunner().invoke(cli.copy, input=b"sample")
@@ -121,3 +138,23 @@ class TestCliCopyPaste(CliTestCase):
 
             with open("output.dat", "rb") as output_file:
                 self.assertEqual(sample_data, output_file.read())
+
+
+class TestCliClear(CliTestCase):
+    def test_clear(self):
+        runner = CliRunner()
+        result = runner.invoke(cli.copy, input=b"sample")
+        self.assertEqual(0, result.exit_code)
+
+        result = runner.invoke(cli.clear)
+        self.assertEqual(0, result.exit_code)
+        self.assertIn("Clipboard cleared.", result.output)
+
+        conn = fakeredis.FakeStrictRedis(server=self.server)
+        self.assertIsNone(conn.get("klippy.default"))
+
+    def test_clear_connection_failure(self):
+        self.server.connected = False
+        result = CliRunner().invoke(cli.clear)
+        self.assertEqual(1, result.exit_code)
+        self.assertIn("Clear failed", result.output)


### PR DESCRIPTION
## Stack 7/8 — merge after #323

## Changes

- `klippy copy --expire/-e DURATION` sets a Redis TTL on the clip. Durations require a unit: `90s`, `5m`, `2h`, `1d`; unitless, invalid or zero durations are rejected as usage errors.
- `klippy clear` deletes the current clip.
- Both reuse the RedisError → ClickException handling from #322, README updated with examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)