### PR TITLE
chore: add devcontainer for development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,18 @@
+# Pin the interpreter from the official image so it always matches .python-version,
+# rather than trusting a feature to install a (still very new) 3.14.
+FROM python:3.14-slim-bookworm
+
+# Minimal extras the slim image lacks. redis-tools gives `redis-cli` for poking
+# at the sidecar; libsecret-tools lets cship read Claude API usage limits; the
+# rest are baseline dev/feature prerequisites.
+# User creation, zsh, and the GitHub CLI are handled by devcontainer features.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        less \
+        libsecret-tools \
+        redis-tools \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,29 @@
+services:
+  app:
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - ../..:/workspaces:cached
+      - claude:/home/vscode/.claude # persists Claude auth + config (incl. statusline) across rebuilds
+      - config:/home/vscode/.config # persists gh login + cship.toml across rebuilds
+      - zsh:/home/vscode/.cache/zsh # persists shell history
+    command: sleep infinity
+    environment:
+      CLAUDE_CONFIG_DIR: /home/vscode/.claude
+      HISTFILE: /home/vscode/.cache/zsh/history
+      KLIPPY_REDIS_HOST: redis # informational; config.ini is the source of truth
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/data
+
+volumes:
+  claude:
+  config:
+  zsh:
+  redis-data:

--- a/.devcontainer/cship.toml
+++ b/.devcontainer/cship.toml
@@ -1,0 +1,39 @@
+[cship]
+lines = [
+  "$starship_prompt",
+  "$cship.model  $cship.cost  $cship.context_bar  $cship.usage_limits  $cship.peak_usage",
+]
+
+[cship.model]
+symbol = " "
+style  = "bold cyan"
+
+[cship.context_bar]
+symbol             = " "
+filled_char        = "●"
+empty_char         = "○"
+format             = "[$symbol$value]($style)"
+width              = 10
+style              = "fg:#7dcfff"
+warn_threshold     = 40.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 70.0
+critical_style     = "bold fg:#f7768e"
+
+[cship.cost]
+symbol             = "💰 "
+style              = "fg:#a9b1d6"
+warn_threshold     = 10
+warn_style         = "fg:#e0af68"
+critical_threshold = 50
+critical_style     = "bold fg:#f7768e"
+
+[cship.usage_limits]
+five_hour_format   = " {pct}% ({reset})"
+seven_day_format   = " {pct}% ({reset})"
+extra_usage_format = ""
+separator          = "  "
+warn_threshold     = 50.0
+warn_style         = "fg:#e0af68"
+critical_threshold = 80.0
+critical_style     = "bold fg:#f7768e"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Klippy",
+  "dockerComposeFile": "compose.yaml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "remoteUser": "vscode",
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "configureZshAsDefaultShell": true,
+      "username": "vscode"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "bash .devcontainer/postCreate.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/workspaces/klippy/.venv/bin/python",
+        "python.testing.pytestEnabled": true,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+          "source.organizeImports": true
+        },
+        "files.exclude": {
+          ".pytest_cache": true,
+          ".venv": true,
+          "**/__pycache__": true,
+          "*.egg-info": true
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Keep post-create output quiet: the dev container echoes every line of stdout
+# as "info" noise. Send verbose tool chatter to /dev/null while letting errors
+# (stderr) through, so a real failure is still visible.
+
+# Named volumes mount root-owned on first create, and mounting one at a
+# subdirectory (.cache/zsh) leaves the parent (.cache) root-owned too. Hand
+# the whole tree to the dev user so tools can create their own caches under it.
+sudo chown -R vscode:vscode "$HOME/.claude" "$HOME/.config" "$HOME/.cache"
+
+# Build a virtualenv and install klippy editable with dev deps
+# (same command the CI workflows use).
+python -m venv .venv >/dev/null
+# shellcheck source=/dev/null
+source .venv/bin/activate
+python -m pip install --quiet --upgrade pip
+pip install --quiet -e . --group dev
+
+# Install the Claude CLI via the native installer (no Node required).
+if ! command -v claude >/dev/null 2>&1; then
+  curl -fsSL https://claude.ai/install.sh | bash >/dev/null
+fi
+
+# Install cship (Claude Code statusline). The installer also wires up the
+# statusLine entry in ~/.claude/settings.json, which the claude volume persists.
+# --yes auto-installs its prerequisites non-interactively (including Starship).
+if ! command -v cship >/dev/null 2>&1; then
+  curl -fsSL https://cship.dev/install.sh | bash -s -- --yes >/dev/null
+fi
+
+# Seed the cship config on first boot. The .config volume persists it, so we
+# only copy when absent to avoid clobbering live tweaks on rebuild.
+if [ ! -f "$HOME/.config/cship.toml" ]; then
+  cp .devcontainer/cship.toml "$HOME/.config/cship.toml"
+fi
+
+# Auto-configure klippy to talk to the redis sidecar so `klippy doctor`
+# passes on first boot. Schema mirrors src/klippy/config.py.
+config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/klippy"
+mkdir -p "$config_dir"
+if [ ! -f "$config_dir/config.ini" ]; then
+  cat >"$config_dir/config.ini" <<'EOF'
+[main]
+namespace = default
+
+[redis]
+host = redis
+port = 6379
+password =
+EOF
+fi
+
+# Make the native-installed `claude` discoverable and auto-activate the venv.
+if ! grep -q "# Klippy devcontainer" "$HOME/.zshrc" 2>/dev/null; then
+  {
+    echo ""
+    echo "# Klippy devcontainer"
+    echo 'export PATH="$HOME/.local/bin:$PATH"'
+    echo "source /workspaces/klippy/.venv/bin/activate"
+  } >>"$HOME/.zshrc"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ build/
 dist/
 
 # Environments
-venv/
+.venv/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,35 @@ klippy paste | cat
 klippy clear
 ```
 
+## 🛠️ Development
+
+This repo ships a [DevPod](https://devpod.sh/)-compatible devcontainer that provisions
+Python 3.14, a Redis sidecar (pre-configured so `klippy doctor` passes out of the box),
+and the Claude CLI. Your Claude login is stored on a named volume, so you only authenticate
+once even across rebuilds.
+
+```bash
+# Start the workspace without launching an IDE
+devpod up . --ide none
+
+# Drop into a shell (the venv auto-activates on login)
+devpod ssh klippy
+```
+
+Inside the container, the project is at `/workspaces/klippy` with everything on `PATH`:
+
+```bash
+pytest                      # run the test suite (uses fakeredis, no Redis needed)
+ruff check . && black .     # lint and format
+klippy doctor               # verify the connection to the Redis sidecar
+echo "hello" | klippy copy && klippy paste
+
+claude                      # the Claude CLI, ready to use
+```
+
+Edit with vim/your editor of choice over SSH. To rebuild from scratch (auth still
+persists): `devpod up . --recreate --ide none`.
+
 ## 🧞‍♂️ Wishlist
 
 - Introduce clipboard history


### PR DESCRIPTION
## Summary
Adds a DevPod / dev-containers-compatible development setup:

- **Python 3.14 image** with a **Redis sidecar**, pre-configured so `klippy doctor` passes out of the box
- The **Claude CLI** and the **cship** statusline, with auth persisted on a named volume across rebuilds
- `postCreate.sh` provisions the venv and installs klippy editable with dev deps (same as CI)

`postCreate` output is kept quiet — the dev container echoes every stdout line as `info` noise, so verbose tool chatter (pip, the `claude`/`cship` installers, the `cship explain` table) is redirected to `/dev/null` while errors still flow through stderr.

Also documents the workflow in the README and switches `.gitignore` from `venv/` to `.venv/` to match the path the devcontainer uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)